### PR TITLE
Fix correct answers

### DIFF
--- a/amd/src/input.js
+++ b/amd/src/input.js
@@ -38,7 +38,7 @@ define(['jquery', 'qtype_shortmath/visual-math-input'], function($, VisualMath) 
 
             if (!input.$input.prop('readonly')) {
                 input.onEdit = function($input, field) {
-                    $input.val('\\[' + field.latex() + '\\]');
+                    $input.val(field.latex());
                     $input.get(0).dispatchEvent(new Event('change')); // Event firing needs to be on a vanilla dom object.
                 };
 
@@ -49,7 +49,7 @@ define(['jquery', 'qtype_shortmath/visual-math-input'], function($, VisualMath) 
 
             if ($shortanswerInput.val()) {
                 input.field.write(
-                    $shortanswerInput.val().slice(2, -2)
+                    $shortanswerInput.val()
                 );
             }
 

--- a/question.php
+++ b/question.php
@@ -17,8 +17,7 @@
 /**
  * @package    qtype
  * @subpackage shortmath
- * @author     André Storhaug <andr3.storhaug@gmail.com>, Sebastian S. Gundersen <sebastsg@stud.ntnu.no>
- *             and Hans Georg Schaathun <hasc@ntnu.no>
+ * @author     André Storhaug <andr3.storhaug@gmail.com>
  * @copyright  2018 NTNU
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -28,11 +27,17 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/question/type/shortanswer/question.php');
 
 /**
- * @author     André Storhaug <andr3.storhaug@gmail.com>, Sebastian S. Gundersen <sebastsg@stud.ntnu.no>
- *             and Hans Georg Schaathun <hasc@ntnu.no>
+ * @author     André Storhaug <andr3.storhaug@gmail.com>
  * @copyright  2018 NTNU
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class qtype_shortmath_question extends qtype_shortanswer_question {
 
+    public function summarise_response(array $response) {
+        if (isset($response['answer'])) {
+            return '\\[' . $response['answer'] . '\\]';
+        } else {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
This fixes the problem with correct answers.

Since mod_jazzquiz needs to retrieve MathJax compatible math formulas, the prefix "\[" and postfix "\]" was previously added to the student answer. This resulted in breaking the auto grading and turning the "correct answer" useless.

With this PR, ShortMath now functions with all the standard question functions, for example specifying correct answers, auto grading etc.